### PR TITLE
Allow nightly running

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -37,12 +37,18 @@ namespace :distiller do
 
   end
 
-  task :distil_pages, :pages do |task, args|
-    Distiller::Distil.perform(args[:pages])
-  end
+  namespace :distil do
+    task :pages, :pages do |task, args|
+      Distiller::Distil.perform(args[:pages])
+    end
 
-  task :distil, :start_index, :step do |task, args|
-    Distiller::Distil.perform(nil, args[:start_index].to_i, args[:step].to_i)
+    task :all, :start_index, :step do |task, args|
+      Distiller::Distil.perform(nil, args[:start_index].to_i, args[:step].to_i)
+    end
+
+    task :latest do
+      Distiller::Distil.latest
+    end
   end
 
 end

--- a/lib/distil.rb
+++ b/lib/distil.rb
@@ -12,32 +12,35 @@ module Distiller
         response = request_with_retries(url.to_s)
 
         response['addresses'].each do |address|
-          postcode = get_postcode(address)
-
-          street = get_street(address)
-          locality = get_locality(address, postcode)
-          town = get_town(address)
-
-          a = Address.create(
-            sao: address['saon']['name'],
-            pao: address['paon']['name'],
-            street: street,
-            locality: locality,
-            town: town,
-            postcode: postcode,
-            provenance: {
-              activity: {
-                executed_at: DateTime.now,
-                processing_scripts: "https://github.com/OpenAddressesUK/distiller",
-                derived_from: derivations(address, [postcode, street, locality, town])
-              }
-            }
-          )
-
-          if a.valid?
-            puts "Address #{a.full_address} created"
-          end
+          create_address(address)
         end
+      end
+    end
+
+    def self.create_address(address)
+      postcode = get_postcode(address)
+      street = get_street(address)
+      locality = get_locality(address, postcode)
+      town = get_town(address)
+
+      a = Address.create(
+        sao: address['saon']['name'],
+        pao: address['paon']['name'],
+        street: street,
+        locality: locality,
+        town: town,
+        postcode: postcode,
+        provenance: {
+          activity: {
+            executed_at: DateTime.now,
+            processing_scripts: "https://github.com/OpenAddressesUK/distiller",
+            derived_from: derivations(address, [postcode, street, locality, town])
+          }
+        }
+      )
+
+      if a.valid?
+        puts "Address #{a.full_address} created"
       end
     end
 

--- a/lib/distiller.rb
+++ b/lib/distiller.rb
@@ -13,6 +13,7 @@ require 'httparty'
 require 'nokogiri'
 require 'zip'
 require 'uk_postcode'
+require 'addressable/uri'
 
 require 'helpers'
 require 'import'


### PR DESCRIPTION
This PR builds on https://github.com/OpenAddressesUK/ernest/pull/21, and adds a new method to take the updated_at
date of the latest address and asks Ernest if there are any new ones. If there are, it distils those addresses.

Currently this assumes they are all new addresses, and doesn't do any of the advanced distillation. I assume this will come in a later sprint.