### PR TITLE
Add UPRN support

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--format documentation

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/OpenAddressesUK/mongoid_address_models.git
-  revision: 8b12197dd91f5b54b47f54d7d78d748ea2756826
+  revision: d926cdb07f3a43fb697f20ea6c100d7d8813c072
   specs:
     mongoid_address_models (0.0.1)
       mongoid
@@ -79,7 +79,7 @@ GEM
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
     method_source (0.8.2)
-    mime-types (2.4.3)
+    mime-types (2.5)
     mini_portile (0.6.1)
     minitest (5.4.2)
     moneta (0.8.0)
@@ -151,7 +151,7 @@ GEM
     rubyzip (1.1.6)
     safe_yaml (1.0.4)
     slop (3.6.0)
-    sprockets (3.0.1)
+    sprockets (3.0.3)
       rack (~> 1.0)
     sprockets-rails (2.2.4)
       actionpack (>= 3.0)

--- a/lib/distil.rb
+++ b/lib/distil.rb
@@ -42,6 +42,23 @@ module Distiller
 
       if a.valid?
         puts "Address #{a.full_address} created"
+      else
+        if address['uprn'] && address['uprn']['name'] != nil
+          existing_address = Address.where(full_address: a.full_address).first
+          existing_address.uprn = address['uprn']['name']
+          existing_address.provenance["activity"]["executed_at"] = DateTime.now
+          existing_address.provenance["activity"]["derived_from"] << {
+            type: "Source",
+            urls: [
+              address["url"]
+            ],
+            downloaded_at: DateTime.now,
+            processing_script: "https://github.com/OpenAddressesUK/distiller/tree/#{current_sha}/lib/distil.rb"
+          }
+
+          existing_address.save
+          puts "Address #{existing_address.full_address} updated with uprn #{existing_address.uprn}"
+        end
       end
     end
 

--- a/spec/distil_spec.rb
+++ b/spec/distil_spec.rb
@@ -208,7 +208,56 @@ describe Distiller::Distil do
     end
 
     it 'updates an existing address with a UPRN' do
-      a = FactoryGirl.create(:address)
+      Timecop.freeze("2015-01-01")
+
+      a = FactoryGirl.create(:address,
+                            pao: 123,
+                            street: FactoryGirl.create(:street, name: "TEST ROAD", easting_northing: [406043, 286921]),
+                            locality: FactoryGirl.create(:locality, name: "KINGS HEATH"),
+                            town: FactoryGirl.create(:town, name: "BIRMINGHAM"),
+                            postcode: FactoryGirl.create(:postcode, name: "B1 2NN", easting_northing: [406137,286927]),
+                            provenance: {
+                              "activity" => {
+                                "executed_at" => Time.parse("2014-01-01").utc,
+                                "processing_scripts" => "https://github.com/OpenAddressesUK/distiller",
+                                "derived_from" => [
+                                  {
+                                    "type" => "Source",
+                                    "urls" => [
+                                      "http://ernest.openaddressesuk.org/addresses/1"
+                                    ],
+                                    "downloaded_at" => Time.parse("2014-01-01").utc,
+                                    "processing_script" => "https://github.com/OpenAddressesUK/distiller/tree/sdasdasdasd/lib/distil.rb"
+                                  },
+                                  {
+                                    "type" => "Source",
+                                    "urls" => [
+                                      "http://alpha.openaddressesuk.org/postcodes/44323"
+                                    ],
+                                    "downloaded_at" => Time.parse("2014-01-01").utc,
+                                    "processing_script" => "https://github.com/OpenAddressesUK/distiller/tree/sdasdasdasd/lib/distil.rb"
+                                  },
+                                  {
+                                    "type" => "Source",
+                                    "urls" => [
+                                      "http://alpha.openaddressesuk.org/streets/34534534"
+                                    ],
+                                    "downloaded_at" => Time.parse("2014-01-01").utc,
+                                    "processing_script" => "https://github.com/OpenAddressesUK/distiller/tree/sdasdasdasd/lib/distil.rb"
+                                  },
+                                  {
+                                    "type" => "Source",
+                                    "urls" => [
+                                      "http://alpha.openaddressesuk.org/towns/43534"
+                                    ],
+                                    "downloaded_at" => Time.parse("2014-01-01").utc,
+                                    "processing_script" => "https://github.com/OpenAddressesUK/distiller/tree/sdasdasdasd/lib/distil.rb"
+                                  }
+                                ]
+                              }
+                            }
+                            )
+
       allow(Distiller::Distil).to receive(:current_sha).and_return("sdasdasdasd")
 
       data = {
@@ -217,7 +266,7 @@ describe Distiller::Distil do
         "total" => 25,
         "addresses" => [
           {
-            "url" => "http://ernest.openaddressesuk.org/addresses/1",
+            "url" => "http://ernest.openaddressesuk.org/addresses/2",
             "uprn" => {
               "name" => "100012345678"
             },
@@ -285,6 +334,11 @@ describe Distiller::Distil do
       Distiller::Distil.perform
       expect(Address.count).to eq 1
       expect(Address.first.uprn).to eq '100012345678'
+      expect(Address.first.provenance["activity"]["executed_at"]).to eq(Time.parse("2015-01-01"))
+      expect(Address.first.provenance["activity"]["derived_from"].count).to eq(5)
+      expect(Address.first.provenance["activity"]["derived_from"].last["urls"].last).to eq("http://ernest.openaddressesuk.org/addresses/2")
+
+      Timecop.return
     end
 
   end


### PR DESCRIPTION
This assumes that any ETL that has UPRNs will submit the full address as well. If an address already exists, we add the UPRN and adjust the provenance to suit.